### PR TITLE
Reject

### DIFF
--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -15,4 +15,4 @@
 
 - name: Autoload the rules
   template: src=etc/network/if-up.d/iptables_load.j2 dest={{iptables_load_path}} owner=root group=root mode=751
-  when: iptables_load_path
+  when: (iptables_load_path is defined) and (iptables_load_path != "")

--- a/templates/etc/iptables.rules.j2
+++ b/templates/etc/iptables.rules.j2
@@ -54,5 +54,5 @@ iptables -A INPUT -m limit --limit 15/minute -j LOG --log-level 7 --log-prefix "
 
 {% if iptables_deny_all %}
 # Drop all other
-iptables -A INPUT -j DROP
+iptables -A INPUT -j REJECT
 {% endif %}


### PR DESCRIPTION
**Description:** Replaces the DROP statement with a REJECT statement, informing communications partners that a packet was suppressed by the firewall. Thus allows clients to continue without having to wait for the inevitable timeout.
The other commit with the ansible 2.2.1 fix is already in production (was pulled into the `system-management` repo from my fork of the branch) and only shows up here because the branch I based the Molmed Fork off didn't have it yet.

**Risk analysis:** this gives a bit more information to would-be attackers, but does not change the overall security in terms of what is allowed and what isn't.

**Validation procedure:** not validated yet, I plan to do that when I pull this into `system-management`

